### PR TITLE
Add speaker display names in transcripts

### DIFF
--- a/llm-simulation-frontend/src/components/TranscriptModal.jsx
+++ b/llm-simulation-frontend/src/components/TranscriptModal.jsx
@@ -87,11 +87,13 @@ const TranscriptModal = ({ open, onClose, session }) => {
   };
 
   // Helper function to get display name for speaker
-  const getSpeakerDisplayName = (speaker) => {
+  const getSpeakerDisplayName = (entry) => {
+    if (!entry) return 'Unknown';
+    if (entry.speaker_display) return entry.speaker_display;
+    const speaker = typeof entry === 'string' ? entry : entry.speaker;
     if (!speaker) return 'Unknown';
     if (speaker === 'client') return 'Client';
     if (speaker.startsWith('agent_')) {
-      // Extract agent type from speaker (e.g., "agent_agent" -> "Agent", "agent_support" -> "Support Agent")
       const agentType = speaker.replace('agent_', '');
       return agentType === 'agent' ? 'Agent' : `${agentType.charAt(0).toUpperCase() + agentType.slice(1)} Agent`;
     }
@@ -248,7 +250,7 @@ const TranscriptModal = ({ open, onClose, session }) => {
 
     text += session.conversation_history
       .map((entry, index) => {
-        let entryText = `${index + 1}. ${getSpeakerDisplayName(entry.speaker).toUpperCase()}: ${entry.content || '[No content]'}`;
+        let entryText = `${index + 1}. ${getSpeakerDisplayName(entry).toUpperCase()}: ${entry.content || '[No content]'}`;
         
         // Add tool calls information
         if (entry.tool_calls && entry.tool_calls.length > 0) {
@@ -309,7 +311,7 @@ const TranscriptModal = ({ open, onClose, session }) => {
 
     text += session.conversation_history
       .map((entry, index) => {
-        let entryText = `${index + 1}. ${getSpeakerDisplayName(entry.speaker).toUpperCase()}: ${entry.content || '[No content]'}`;
+        let entryText = `${index + 1}. ${getSpeakerDisplayName(entry).toUpperCase()}: ${entry.content || '[No content]'}`;
         
         // Add tool calls information
         if (entry.tool_calls && entry.tool_calls.length > 0) {
@@ -507,7 +509,7 @@ const TranscriptModal = ({ open, onClose, session }) => {
                           </Avatar>
                           <Box sx={{ flex: 1 }}>
                             <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-                              {getSpeakerDisplayName(entry.speaker)}
+                              {getSpeakerDisplayName(entry)}
                             </Typography>
                             <Typography variant="caption" color="text.secondary">
                               Turn {entry.turn || index + 1}

--- a/llm-simulation-service/docs/contracts/service_layer_contracts/conversational_engine_contract.md
+++ b/llm-simulation-service/docs/contracts/service_layer_contracts/conversational_engine_contract.md
@@ -84,9 +84,10 @@ The `conversation_history` is a list of turn objects. Each turn has different st
 
 #### Basic Turn (no tools)
 ```python
-{
+{ 
     "turn": int,                    # Turn number (1, 2, 3, etc.)
     "speaker": str,                 # "agent" | "client" | "agent_{agent_name}"
+    "speaker_display": str,         # Optional descriptive name
     "content": str,                 # The actual message content
     "timestamp": str                # ISO format timestamp
 }
@@ -97,6 +98,7 @@ The `conversation_history` is a list of turn objects. Each turn has different st
 {
     "turn": int,                    # Turn number
     "speaker": str,                 # "agent_{agent_name}" | "client"
+    "speaker_display": str,         # Optional descriptive name
     "content": str,                 # Message content (can be empty string)
     "tool_calls": List[Dict],       # List of tool call objects
     "tool_results": List[Any],      # List of parsed tool results (agent only)
@@ -192,6 +194,15 @@ Tool results are the parsed responses from tool executions. The structure varies
     ],
     "timestamp": "2025-06-26T18:07:12.088764"
 }
+```
+
+### Example with Display Names
+
+```python
+[
+    {"turn": 1, "speaker": "agent_sales_agent", "speaker_display": "Sales Agent", "content": "Hello"},
+    {"turn": 2, "speaker": "client", "speaker_display": "Client", "content": "Hi"}
+]
 ```
 
 ## Integration Points

--- a/llm-simulation-service/src/autogen_conversation_engine.py
+++ b/llm-simulation-service/src/autogen_conversation_engine.py
@@ -366,7 +366,10 @@ class AutogenConversationEngine:
                             'total_turns': turn_count,
                             'duration_seconds': duration,
                             'tools_used': True,
-                            'conversation_history': ConversationAdapter.extract_conversation_history(all_messages),
+                            'conversation_history': ConversationAdapter.extract_conversation_history(
+                                all_messages,
+                                self.prompt_specification
+                            ),
                             'start_time': datetime.fromtimestamp(start_time).isoformat(),
                             'end_time': datetime.fromtimestamp(end_time).isoformat(),
                             'mas_stop_reason': task_result.stop_reason,
@@ -428,7 +431,8 @@ class AutogenConversationEngine:
                     session_id=session_id,
                     scenario_name=scenario_name,
                     duration=duration,
-                    start_time=start_time
+                    start_time=start_time,
+                    prompt_spec=self.prompt_specification
                 )
                 
                 # Log conversation completion
@@ -455,7 +459,10 @@ class AutogenConversationEngine:
                     }
                 )
 
-                history = ConversationAdapter.extract_conversation_history(all_messages)
+                history = ConversationAdapter.extract_conversation_history(
+                    all_messages,
+                    self.prompt_specification
+                )
 
                 # Return timeout result in contract format
                 return {


### PR DESCRIPTION
## Summary
- pass prompt specifications when building conversation history
- store `speaker_display` in history entries and expose from frontend
- show display names in UI and docs
- add unit test for `speaker_display`

## Testing
- `PYTHONPATH=. pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_6860543c19fc8321917b8122519b22e7