### PR TITLE
Clarify history format in service README

### DIFF
--- a/llm-simulation-service/README.md
+++ b/llm-simulation-service/README.md
@@ -123,3 +123,19 @@ graph TB
 - [Service Contracts](docs/contracts/service_layer_contracts/) - Internal service interfaces
 - [Storage Contracts](docs/contracts/storage_contracts/) - Data persistence interfaces
 - [Infrastructure Contracts](docs/contracts/infra_util_contracts/) - External adapter contracts
+
+### Conversation History
+
+Simulation results include a `conversation_history` array. Each entry contains a
+`speaker_display` field that provides a user-friendly label for the message
+speaker.
+
+```json
+[
+    {"turn": 1, "speaker": "agent_sales_agent", "speaker_display": "Sales Agent", "content": "Hello"},
+    {"turn": 2, "speaker": "client", "speaker_display": "Client", "content": "Hi"}
+]
+```
+
+See the [ConversationEngine contract](docs/contracts/service_layer_contracts/conversational_engine_contract.md)
+for a complete description of all fields.


### PR DESCRIPTION
## Summary
- note that each `conversation_history` entry includes `speaker_display` for easy labels
- show a brief snippet and link to the ConversationEngine contract

## Testing
- `pytest -q` *(fails: async functions not supported)*

------
https://chatgpt.com/codex/tasks/task_e_686064c9d3c88321974affbe45e16ee6