### PR TITLE
Add ConversationHistoryItem schema

### DIFF
--- a/llm-simulation-service/docs/contracts/http_api_openapi.yaml
+++ b/llm-simulation-service/docs/contracts/http_api_openapi.yaml
@@ -51,7 +51,17 @@ paths:
           name: format
           schema: {type: string}
       responses:
-        '200': {description: Results}
+        '200':
+          description: Results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversation_history:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ConversationHistoryItem'
   /api/batches/{id}/summary:
     get:
       summary: Batch summary
@@ -61,7 +71,17 @@ paths:
           required: true
           schema: {type: string}
       responses:
-        '200': {description: Summary}
+        '200':
+          description: Summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversation_history:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ConversationHistoryItem'
   /api/batches/{id}/cost:
     get:
       summary: Cost estimate
@@ -131,3 +151,21 @@ paths:
       summary: Delete user
       responses:
         '204': {description: Deleted}
+
+components:
+  schemas:
+    ConversationHistoryItem:
+      type: object
+      properties:
+        turn: {type: integer}
+        speaker: {type: string}
+        speaker_display: {type: string}
+        content: {type: string}
+        timestamp: {type: string}
+        tool_calls:
+          type: array
+          items: {type: object}
+        tool_results:
+          type: array
+          items: {}
+      required: [turn, speaker, content, timestamp]


### PR DESCRIPTION
## Summary
- document ConversationHistoryItem in OpenAPI docs
- reference the schema in results and summary endpoints

## Testing
- `PYTHONPATH=. pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_686064c92ef483219d92d20ca17eb871