### PR TITLE
Update conversation result docs

### DIFF
--- a/llm-simulation-service/docs/contracts/data_models_contract.md
+++ b/llm-simulation-service/docs/contracts/data_models_contract.md
@@ -14,10 +14,22 @@ Produced by `ConversationEngine.run_conversation`.
 Main keys include:
 - `session_id` – unique ID for the run
 - `scenario` – scenario name
-- `status` – `completed`, `failed`, etc.
+- `status` – one of `completed`, `failed`, `failed_api_blocked`, `timeout`
 - `total_turns` – number of conversation turns
 - `duration_seconds` – execution time
 - `conversation_history` – list of turn objects
+
+#### Example Result
+```json
+{
+    "session_id": "abc123",
+    "scenario": "demo",
+    "status": "failed_api_blocked",
+    "total_turns": 0,
+    "duration_seconds": 0.1,
+    "conversation_history": []
+}
+```
 
 ### Conversation History Structure
 Each turn dictionary contains at least the following fields:


### PR DESCRIPTION
## Summary
- enumerate conversation result status values
- add example JSON snippet illustrating a failed API blocked case

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6860685e3d208321aca525f50432f576