### PR TITLE
Document MAX_INTERNAL_MESSAGES

### DIFF
--- a/llm-simulation-service/docs/configuration/config_system.md
+++ b/llm-simulation-service/docs/configuration/config_system.md
@@ -8,6 +8,7 @@
 - `MAX_TURNS` – conversation turn limit (default `30`).
 - `TIMEOUT_SEC` – timeout per conversation (default `90`).
 - `CONCURRENCY` – number of parallel scenarios (default `4`).
+- `MAX_INTERNAL_MESSAGES` – limits the number of internal agent-to-agent messages before termination (default `10`). A warning is logged when the variable isn’t set.
 - `WEBHOOK_URL` – optional URL for session initialization.
 - `RESULTS_DIR` – directory for exported results (default `results`).
 - `LOGS_DIR` – directory for log files (default `logs`).


### PR DESCRIPTION
## Summary
- document `MAX_INTERNAL_MESSAGES` in configuration docs

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6860685d1bac8321a7d54ba6bb94f6d7