### PR TITLE
[llm-simulation-service] complete variable enricher tests

### DIFF
--- a/llm-simulation-service/docs/modules_overview.md
+++ b/llm-simulation-service/docs/modules_overview.md
@@ -19,6 +19,9 @@ This document provides a comprehensive mapping of all source code modules to the
 | `src/speaker_display_name_resolver.py` | Service | Resolve speaker display names from prompt specs | [SpeakerDisplayNameResolver Contract](contracts/service_layer_contracts/speaker_display_name_resolver_contract.md) |
 | `src/tool_flush_state_machine.py` | Service | Match tool calls/results and flush to messages | [ToolFlushStateMachine Contract](contracts/service_layer_contracts/tool_flush_state_machine_contract.md) |
 | `src/dtos/parsed_message.py` | Service | DTO representing parsed AutoGen message | [ParsedMessage DTO](contracts/dto/parsed_message_dto.md) |
+| `src/conversation_context.py` | Service | Dataclass representing conversation state | N/A |
+| `src/turn_result.py` | Service | Dataclass representing single turn outcome | N/A |
+| `src/scenario_variable_enricher.py` | Service | Scenario variable enrichment helpers | N/A |
 | `src/batch_processor.py` | Service | Parallel batch processing and workflow coordination | [Batch Processor Contract](contracts/service_layer_contracts/batch_processor_contract.md) |
 | `src/evaluator.py` | Service | Conversation scoring and quality assessment logic | [Evaluator Contract](contracts/service_layer_contracts/evaluator_contract.md) |
 | `src/prompt_specification.py` | Service | Agent configuration and prompt management logic | [Prompt Specification Contract](contracts/specification_contracts/prompt_specification_contract.md) |

--- a/llm-simulation-service/src/conversation_context.py
+++ b/llm-simulation-service/src/conversation_context.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass, field
+from typing import List
+from autogen_agentchat.messages import BaseChatMessage
+
+@dataclass
+class ConversationContext:
+    """Encapsulates conversation state and configuration."""
+    session_id: str
+    scenario_name: str
+    max_turns: int
+    timeout_sec: int
+    start_time: float
+    turn_count: int = 0
+    all_messages: List[BaseChatMessage] = field(default_factory=list)

--- a/llm-simulation-service/src/scenario_variable_enricher.py
+++ b/llm-simulation-service/src/scenario_variable_enricher.py
@@ -1,0 +1,55 @@
+"""Service for scenario variable enrichment."""
+from typing import Any, Dict, Optional, Tuple
+
+from src.webhook_manager import WebhookManager
+from src.logging_utils import SimulationLogger
+
+DEFAULTS = {
+    "CURRENT_DATE": "2024-01-15",
+    "current_date": "2024-01-15",
+    "DELIVERY_DAY": "завтра",
+    "delivery_days": "понедельник, среда, пятница",
+    "PURCHASE_HISTORY": "История покупок отсутствует",
+    "purchase_history": "История покупок отсутствует",
+    "name": "Клиент",
+    "locations": "Адрес не указан",
+    "CLIENT_NAME": "Клиент",
+    "LOCATION": "Адрес не указан",
+}
+
+async def enrich_scenario_variables(
+    variables: Dict[str, Any], session_id: str, webhook_manager: WebhookManager, logger: SimulationLogger
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    """Enrich scenario variables with webhook data and defaults."""
+    variables = variables.copy()
+    webhook_session_id = None
+    client_id = variables.get("client_id")
+    client_data = None
+    if client_id:
+        logger.log_info(f"Found client_id in scenario: {client_id}")
+        try:
+            client_data = await webhook_manager.get_client_data(client_id)
+            webhook_session_id = client_data.get("session_id")
+            variables.update(client_data.get("variables", {}))
+        except Exception as exc:  # pragma: no cover - network failure
+            logger.log_error("Failed to fetch client data", exception=exc)
+    _create_lowercase_mappings(variables)
+    variables["session_id"] = session_id
+    _apply_default_values(variables)
+    return variables, webhook_session_id
+
+def _create_lowercase_mappings(variables: Dict[str, Any]) -> None:
+    if "LOCATIONS" in variables and "locations" not in variables:
+        variables["locations"] = variables["LOCATIONS"]
+    if "DELIVERY_DAYS" in variables and "delivery_days" not in variables:
+        variables["delivery_days"] = variables["DELIVERY_DAYS"]
+    if "PURCHASE_HISTORY" in variables and "purchase_history" not in variables:
+        variables["purchase_history"] = variables["PURCHASE_HISTORY"]
+    if "NAME" in variables and "name" not in variables:
+        variables["name"] = variables["NAME"]
+    if "CURRENT_DATE" in variables and "current_date" not in variables:
+        variables["current_date"] = variables["CURRENT_DATE"]
+
+def _apply_default_values(variables: Dict[str, Any]) -> None:
+    for key, default in DEFAULTS.items():
+        variables.setdefault(key, default)

--- a/llm-simulation-service/src/turn_result.py
+++ b/llm-simulation-service/src/turn_result.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from typing import Optional
+from autogen_agentchat.messages import BaseChatMessage
+from autogen_agentchat.base import TaskResult
+
+@dataclass
+class TurnResult:
+    """Represents the outcome of a single conversation turn."""
+    task_result: TaskResult
+    last_message: BaseChatMessage
+    should_continue: bool
+    termination_reason: Optional[str] = None

--- a/llm-simulation-service/tests/test_scenario_variable_enricher.py
+++ b/llm-simulation-service/tests/test_scenario_variable_enricher.py
@@ -1,0 +1,131 @@
+import pytest
+from unittest.mock import AsyncMock, Mock
+
+from src.scenario_variable_enricher import enrich_scenario_variables, DEFAULTS
+from src.webhook_manager import WebhookManager
+from src.logging_utils import SimulationLogger
+
+
+class TestScenarioVariableEnricher:
+    @pytest.mark.asyncio
+    async def test_enrich_variables_no_client_id(self):
+        variables = {"NAME": "John", "LOCATIONS": "Moscow"}
+        webhook_manager = Mock(spec=WebhookManager)
+        logger = Mock(spec=SimulationLogger)
+        result, session = await enrich_scenario_variables(
+            variables, "sid", webhook_manager, logger
+        )
+        assert result["name"] == "John"
+        assert result["locations"] == "Moscow"
+        assert result["session_id"] == "sid"
+        assert result["CURRENT_DATE"] == DEFAULTS["CURRENT_DATE"]
+        assert session is None
+
+    @pytest.mark.asyncio
+    async def test_enrich_variables_with_client_id(self):
+        variables = {"client_id": "c1"}
+        webhook_manager = Mock(spec=WebhookManager)
+        webhook_manager.get_client_data = AsyncMock(
+            return_value={"variables": {"NAME": "Alice"}, "session_id": "web_sid"}
+        )
+        logger = Mock(spec=SimulationLogger)
+        result, session = await enrich_scenario_variables(
+            variables, "sid", webhook_manager, logger
+        )
+        assert result["name"] == "Alice"
+        assert result["session_id"] == "sid"
+        assert session == "web_sid"
+
+    @pytest.mark.asyncio
+    async def test_webhook_failure_fallback(self):
+        variables = {"client_id": "c1"}
+        webhook_manager = Mock(spec=WebhookManager)
+        webhook_manager.get_client_data = AsyncMock(side_effect=Exception("fail"))
+        logger = Mock(spec=SimulationLogger)
+        result, session = await enrich_scenario_variables(
+            variables, "sid", webhook_manager, logger
+        )
+        assert result["name"] == DEFAULTS["name"]
+        assert session is None
+
+    @pytest.mark.asyncio
+    async def test_default_value_application(self):
+        variables = {}
+        webhook_manager = Mock(spec=WebhookManager)
+        logger = Mock(spec=SimulationLogger)
+        result, _ = await enrich_scenario_variables(
+            variables, "sid", webhook_manager, logger
+        )
+        for key, value in DEFAULTS.items():
+            assert result[key] == value
+
+    @pytest.mark.asyncio
+    async def test_variable_override_priority(self):
+        variables = {"client_id": "c1", "NAME": "John"}
+        webhook_manager = Mock(spec=WebhookManager)
+        webhook_manager.get_client_data = AsyncMock(
+            return_value={"variables": {"NAME": "Alice"}, "session_id": None}
+        )
+        logger = Mock(spec=SimulationLogger)
+        result, _ = await enrich_scenario_variables(
+            variables, "sid", webhook_manager, logger
+        )
+        assert result["NAME"] == "Alice"
+        assert result["name"] == "Alice"
+
+    @pytest.mark.asyncio
+    async def test_session_id_integration(self):
+        variables = {}
+        webhook_manager = Mock(spec=WebhookManager)
+        logger = Mock(spec=SimulationLogger)
+        result, _ = await enrich_scenario_variables(
+            variables, "sid", webhook_manager, logger
+        )
+        assert result["session_id"] == "sid"
+
+    @pytest.mark.asyncio
+    async def test_lowercase_mapping_creation(self):
+        variables = {
+            "NAME": "JOHN",
+            "LOCATIONS": "NY",
+            "DELIVERY_DAYS": "Mon",
+            "PURCHASE_HISTORY": "p",
+            "CURRENT_DATE": "2025-06-01",
+        }
+        webhook_manager = Mock(spec=WebhookManager)
+        logger = Mock(spec=SimulationLogger)
+        result, _ = await enrich_scenario_variables(
+            variables, "sid", webhook_manager, logger
+        )
+        assert result["name"] == "JOHN"
+        assert result["locations"] == "NY"
+        assert result["delivery_days"] == "Mon"
+        assert result["purchase_history"] == "p"
+        assert result["current_date"] == "2025-06-01"
+
+    @pytest.mark.asyncio
+    async def test_fetch_client_data_success(self):
+        variables = {"client_id": "c1"}
+        webhook_manager = Mock(spec=WebhookManager)
+        webhook_manager.get_client_data = AsyncMock(
+            return_value={"variables": {"NAME": "Alice"}, "session_id": "s1"}
+        )
+        logger = Mock(spec=SimulationLogger)
+        result, session = await enrich_scenario_variables(
+            variables, "sid", webhook_manager, logger
+        )
+        webhook_manager.get_client_data.assert_awaited_once_with("c1")
+        assert session == "s1"
+        assert result["name"] == "Alice"
+
+    @pytest.mark.asyncio
+    async def test_fetch_client_data_no_client_id(self):
+        variables = {}
+        webhook_manager = Mock(spec=WebhookManager)
+        webhook_manager.get_client_data = AsyncMock()
+        logger = Mock(spec=SimulationLogger)
+        result, session = await enrich_scenario_variables(
+            variables, "sid", webhook_manager, logger
+        )
+        webhook_manager.get_client_data.assert_not_called()
+        assert session is None


### PR DESCRIPTION
## Summary
- convert the variable enricher tests into a class and add more cases
- cover webhook failures, default values, override logic and session id handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863afa99640832ca21300333becf0cb