### PR TITLE
[llm-simulation-service] extract turn management

### DIFF
--- a/llm-simulation-service/src/conversation_turn_manager.py
+++ b/llm-simulation-service/src/conversation_turn_manager.py
@@ -1,0 +1,96 @@
+"""Service for managing individual conversation turns."""
+from typing import Optional, Tuple
+
+from autogen_agentchat.teams import Swarm
+from autogen_agentchat.messages import HandoffMessage, TextMessage
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.base import TaskResult
+
+from src.logging_utils import SimulationLogger
+from src.conversation_context import ConversationContext
+from src.turn_result import TurnResult
+
+
+class ConversationTurnManager:
+    """Handle execution of a single conversation turn."""
+
+    def __init__(self, logger: SimulationLogger) -> None:
+        self.logger = logger
+
+    async def execute_turn(
+        self,
+        swarm: Swarm,
+        user_message: str,
+        target_agent: str,
+        context: ConversationContext,
+    ) -> TurnResult:
+        """Run a conversation turn and determine continuation."""
+        context.turn_count += 1
+        self.logger.log_info(
+            f"Turn {context.turn_count}: User -> {target_agent}",
+            extra_data={"session_id": context.session_id, "user_message": user_message[:100]},
+        )
+
+        task_result = await swarm.run(
+            task=HandoffMessage(source="client", target=target_agent, content=user_message)
+        )
+        context.all_messages.extend(task_result.messages)
+
+        last_message = self._validate_agent_response(task_result, context)
+
+        self.logger.log_info(
+            f"Turn {context.turn_count}: {last_message.source} -> User",
+            extra_data={"session_id": context.session_id, "agent_response": last_message.content[:100]},
+        )
+
+        should_continue, reason = self._determine_continuation(task_result, context)
+
+        return TurnResult(
+            task_result=task_result,
+            last_message=last_message,
+            should_continue=should_continue,
+            termination_reason=reason,
+        )
+
+    async def generate_user_response(
+        self, user_agent: AssistantAgent, agent_message: TextMessage
+    ) -> str:
+        """Generate the next user message via user simulation agent."""
+        response = await user_agent.on_messages([agent_message], None)
+        return response.chat_message.content
+
+    def _validate_agent_response(
+        self, task_result: TaskResult, context: ConversationContext
+    ) -> TextMessage:
+        """Ensure the MAS returned a TextMessage."""
+        last_message = task_result.messages[-1]
+        if not isinstance(last_message, TextMessage):
+            error = TypeError(
+                f"MAS terminated with non-text message ({type(last_message).__name__})"
+            )
+            error.task_result = task_result
+            raise error
+        return last_message
+
+    def _determine_continuation(
+        self, task_result: TaskResult, context: ConversationContext
+    ) -> Tuple[bool, Optional[str]]:
+        """Decide whether the conversation should continue."""
+        if task_result.stop_reason and any(
+            term in task_result.stop_reason.lower()
+            for term in ["terminate", "end", "finished", "completed"]
+        ):
+            self.logger.log_info(
+                f"Conversation ended naturally: {task_result.stop_reason}",
+                extra_data={"session_id": context.session_id},
+            )
+            return False, task_result.stop_reason
+
+        if context.turn_count >= context.max_turns:
+            self.logger.log_info(
+                f"Reached max_turns ({context.max_turns})",
+                extra_data={"session_id": context.session_id},
+            )
+            return False, "max_turns"
+
+        return True, None

--- a/llm-simulation-service/tests/test_autogen_conversation_engine_part2.py
+++ b/llm-simulation-service/tests/test_autogen_conversation_engine_part2.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import ANY, AsyncMock, Mock, patch
+
+from autogen_agentchat.messages import TextMessage
+from autogen_agentchat.base import TaskResult
+
+from src.autogen_conversation_engine import AutogenConversationEngine
+from src.openai_wrapper import OpenAIWrapper
+from src.turn_result import TurnResult
+
+
+class TestAutogenConversationEnginePart2:
+    def setup_method(self):
+        self.mock_openai_wrapper = Mock(spec=OpenAIWrapper)
+        self.mock_openai_wrapper.client = Mock()
+        self.mock_openai_wrapper.client.api_key = "key"
+        with patch("src.autogen_conversation_engine.PromptSpecificationManager") as mgr, patch(
+            "src.autogen_conversation_engine.WebhookManager"
+        ) as wh:
+            mgr.return_value.load_specification.return_value = Mock(agents={"agent": Mock()}, version="1.0")
+            wh.return_value = Mock(initialize_session=AsyncMock(return_value="sid"))
+            self.engine = AutogenConversationEngine(self.mock_openai_wrapper)
+            self.engine.webhook_manager = wh.return_value
+
+    @pytest.mark.asyncio
+    async def test_turn_management_integration(self):
+        scenario = {"name": "sc", "variables": {}}
+        with (
+            patch("src.autogen_conversation_engine.AutogenModelClientFactory.create_from_openai_wrapper") as create_client,
+            patch.object(self.engine, "_create_user_agent") as create_user_agent,
+            patch("src.autogen_conversation_engine.AutogenToolFactory") as tool_factory_cls,
+            patch("src.autogen_conversation_engine.AutogenMASFactory") as mas_factory_cls,
+            patch("src.autogen_conversation_engine.ConversationAdapter") as adapter_cls,
+            patch.object(self.engine.prompt_specification, "format_with_variables") as format_spec,
+            patch.object(self.engine, "_enrich_variables_with_client_data") as enrich,
+            patch.object(self.engine.turn_manager, "execute_turn", new_callable=AsyncMock) as exec_turn,
+            patch.object(self.engine.turn_manager, "generate_user_response", new_callable=AsyncMock) as gen_resp,
+        ):
+            create_client.return_value = Mock()
+            create_user_agent.return_value = Mock()
+            tool_factory_cls.return_value.get_tools_for_agent.return_value = []
+            mock_swarm = Mock()
+            mas_factory_cls.return_value.create_swarm_team.return_value = mock_swarm
+            adapter_cls.autogen_to_contract_format.return_value = {"session_id": "sid", "status": "completed"}
+            format_spec.return_value = Mock(agents={"agent": Mock(tools=[])})
+            enrich.return_value = ({"session_id": "sid"}, None)
+            msg = TextMessage(content="hi", source="agent")
+            task_result = TaskResult(messages=[msg], stop_reason="completed")
+            exec_turn.return_value = TurnResult(task_result, msg, False, "completed")
+            gen_resp.return_value = "bye"
+
+            result = await self.engine.run_conversation_with_tools(scenario, max_turns=1, timeout_sec=5)
+
+            exec_turn.assert_called_once_with(mock_swarm, "Добрый день!", "agent", ANY)
+            gen_resp.assert_not_called()
+            assert result["status"] == "completed"

--- a/llm-simulation-service/tests/test_conversation_turn_manager.py
+++ b/llm-simulation-service/tests/test_conversation_turn_manager.py
@@ -1,0 +1,99 @@
+import pytest
+from unittest.mock import AsyncMock, Mock
+
+from autogen_agentchat.messages import TextMessage, HandoffMessage
+from autogen_agentchat.base import TaskResult
+
+from src.conversation_turn_manager import ConversationTurnManager
+from src.conversation_context import ConversationContext
+from src.turn_result import TurnResult
+from src.logging_utils import SimulationLogger
+
+
+@pytest.fixture
+def context():
+    return ConversationContext(
+        session_id="sid",
+        scenario_name="sc",
+        max_turns=3,
+        timeout_sec=10,
+        start_time=0.0,
+    )
+
+
+@pytest.fixture
+def logger():
+    return Mock(spec=SimulationLogger)
+
+
+class TestConversationTurnManager:
+    @pytest.mark.asyncio
+    async def test_execute_turn_success(self, context, logger):
+        manager = ConversationTurnManager(logger)
+        swarm = Mock()
+        msg = TextMessage(content="hi", source="agent")
+        swarm.run = AsyncMock(return_value=TaskResult(messages=[msg], stop_reason=None))
+
+        result = await manager.execute_turn(swarm, "hello", "agent", context)
+
+        assert isinstance(result, TurnResult)
+        assert context.turn_count == 1
+        assert context.all_messages == [msg]
+        assert result.should_continue is True
+        assert result.termination_reason is None
+
+    @pytest.mark.asyncio
+    async def test_execute_turn_non_text_message(self, context, logger):
+        manager = ConversationTurnManager(logger)
+        swarm = Mock()
+        non_text = HandoffMessage(content="handoff", source="agent", target="user")
+        swarm.run = AsyncMock(return_value=TaskResult(messages=[non_text], stop_reason=None))
+
+        with pytest.raises(TypeError):
+            await manager.execute_turn(swarm, "hello", "agent", context)
+
+    @pytest.mark.asyncio
+    async def test_generate_user_response_success(self, logger):
+        manager = ConversationTurnManager(logger)
+        agent = Mock()
+        agent.on_messages = AsyncMock(return_value=Mock(chat_message=TextMessage(content="pong", source="agent")))
+
+        result = await manager.generate_user_response(agent, TextMessage(content="ping", source="agent"))
+
+        assert result == "pong"
+
+    def test_validate_agent_response_text_message(self, context, logger):
+        manager = ConversationTurnManager(logger)
+        msg = TextMessage(content="hi", source="agent")
+        task_result = TaskResult(messages=[msg], stop_reason=None)
+        assert manager._validate_agent_response(task_result, context) is msg
+
+    def test_validate_agent_response_non_text_message(self, context, logger):
+        manager = ConversationTurnManager(logger)
+        task_result = TaskResult(messages=[HandoffMessage(content="x", source="a", target="b")], stop_reason=None)
+        with pytest.raises(TypeError):
+            manager._validate_agent_response(task_result, context)
+
+    def test_determine_continuation_natural_end(self, context, logger):
+        manager = ConversationTurnManager(logger)
+        context.turn_count = 1
+        task_result = TaskResult(messages=[TextMessage(content="hi", source="agent")], stop_reason="finished")
+        cont, reason = manager._determine_continuation(task_result, context)
+        assert cont is False
+        assert reason == "finished"
+
+    def test_determine_continuation_max_turns(self, context, logger):
+        manager = ConversationTurnManager(logger)
+        context.turn_count = 3
+        task_result = TaskResult(messages=[TextMessage(content="hi", source="agent")], stop_reason=None)
+        cont, reason = manager._determine_continuation(task_result, context)
+        assert cont is False
+        assert reason == "max_turns"
+
+    def test_determine_continuation_ongoing(self, context, logger):
+        manager = ConversationTurnManager(logger)
+        context.turn_count = 1
+        task_result = TaskResult(messages=[TextMessage(content="hi", source="agent")], stop_reason=None)
+        cont, reason = manager._determine_continuation(task_result, context)
+        assert cont is True
+        assert reason is None


### PR DESCRIPTION
## Summary
- add `ConversationTurnManager` service for a single conversation turn
- integrate turn manager into `AutogenConversationEngine`
- add unit tests for turn manager
- add integration test verifying engine uses turn manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863cbad91e4832c8c94c3e8f4533e35