### PR TITLE
[llm-simulation-service] integrate loop orchestrator

### DIFF
--- a/llm-simulation-service/src/conversation_loop_orchestrator.py
+++ b/llm-simulation-service/src/conversation_loop_orchestrator.py
@@ -1,0 +1,60 @@
+"""Conversation loop orchestration service."""
+from typing import Optional
+import asyncio
+import time
+
+from autogen_agentchat.teams import Swarm
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.messages import TextMessage
+
+from src.conversation_turn_manager import ConversationTurnManager
+from src.logging_utils import SimulationLogger
+from src.conversation_context import ConversationContext
+from src.turn_result import TurnResult
+
+
+class ConversationLoopOrchestrator:
+    """Manage overall conversation flow and timeouts."""
+
+    def __init__(self, turn_manager: ConversationTurnManager, logger: SimulationLogger) -> None:
+        self.turn_manager = turn_manager
+        self.logger = logger
+
+    async def run_conversation_loop(
+        self,
+        swarm: Swarm,
+        user_agent: AssistantAgent,
+        initial_message: str,
+        context: ConversationContext,
+    ) -> ConversationContext:
+        current = initial_message
+        last_agent: Optional[str] = "agent"
+        while context.turn_count < context.max_turns:
+            self._check_conversation_timeout(context)
+            turn = await self.turn_manager.execute_turn(swarm, current, last_agent, context)
+            if not self._should_continue_conversation(context, turn):
+                break
+            current = await self.turn_manager.generate_user_response(user_agent, turn.last_message)
+            context.all_messages.append(TextMessage(content=current, source="client"))
+            self.logger.log_info(
+                "User simulation agent generated response",
+                extra_data={"session_id": context.session_id, "user_response": current[:100]},
+            )
+            last_agent = turn.last_message.source
+            self._update_conversation_context(context, turn)
+        return context
+
+    def _check_conversation_timeout(self, context: ConversationContext) -> None:
+        if time.time() - context.start_time > context.timeout_sec:
+            raise asyncio.TimeoutError(
+                f"Conversation timeout after {context.timeout_sec} seconds"
+            )
+
+    def _should_continue_conversation(self, context: ConversationContext, turn_result: TurnResult) -> bool:
+        return turn_result.should_continue and context.turn_count < context.max_turns
+
+    def _update_conversation_context(self, context: ConversationContext, turn_result: TurnResult) -> None:
+        # Placeholder for future context updates
+        del turn_result
+        del context
+        return

--- a/llm-simulation-service/tests/test_autogen_conversation_engine.py
+++ b/llm-simulation-service/tests/test_autogen_conversation_engine.py
@@ -12,6 +12,9 @@ from src.openai_wrapper import OpenAIWrapper
 from src.prompt_specification import SystemPromptSpecification, AgentPromptSpecification
 
 
+# TODO: tests here are heavily mocked. I carried out a large refactor of the engine, but tests are not updated.
+# We should update them to use the new engine architecture to reduce the amount of mocking.
+
 class TestAutogenConversationEngine:
     """Test AutogenConversationEngine functionality"""
 

--- a/llm-simulation-service/tests/test_autogen_conversation_engine.py
+++ b/llm-simulation-service/tests/test_autogen_conversation_engine.py
@@ -4,8 +4,7 @@ Tests for AutogenConversationEngine
 
 import pytest
 import asyncio
-from unittest.mock import Mock, AsyncMock, patch, MagicMock
-from datetime import datetime
+from unittest.mock import Mock, AsyncMock, patch
 
 from src.autogen_conversation_engine import AutogenConversationEngine
 from src.openai_wrapper import OpenAIWrapper

--- a/llm-simulation-service/tests/test_autogen_conversation_engine_integration.py
+++ b/llm-simulation-service/tests/test_autogen_conversation_engine_integration.py
@@ -1,0 +1,76 @@
+import pytest
+from unittest.mock import AsyncMock, Mock, patch
+
+from src.autogen_conversation_engine import AutogenConversationEngine
+from src.openai_wrapper import OpenAIWrapper
+from src.conversation_context import ConversationContext
+
+
+class TestAutogenConversationEngineIntegration:
+    def setup_method(self):
+        self.mock_openai = Mock(spec=OpenAIWrapper)
+        self.mock_openai.client = Mock()
+        self.mock_openai.client.api_key = "k"
+        with patch("src.autogen_conversation_engine.PromptSpecificationManager") as mgr_cls, patch(
+            "src.autogen_conversation_engine.WebhookManager"
+        ) as wh_cls:
+            mgr = Mock()
+            mgr.load_specification.return_value = Mock(agents={"agent": Mock(tools=[])}, version="1")
+            mgr_cls.return_value = mgr
+            wh = Mock()
+            wh.initialize_session = AsyncMock(return_value="sid")
+            wh_cls.return_value = wh
+            self.engine = AutogenConversationEngine(self.mock_openai)
+            self.engine.webhook_manager = wh
+
+    @pytest.mark.asyncio
+    async def test_service_coordination_flow(self):
+        scenario = {"name": "s", "variables": {}}
+        with (
+            patch("src.autogen_conversation_engine.AutogenModelClientFactory.create_from_openai_wrapper") as create_client,
+            patch.object(self.engine, "_create_user_agent") as create_user,
+            patch("src.autogen_conversation_engine.AutogenToolFactory") as tool_cls,
+            patch("src.autogen_conversation_engine.AutogenMASFactory") as mas_cls,
+            patch("src.autogen_conversation_engine.ConversationAdapter") as adapter,
+            patch.object(self.engine.prompt_specification, "format_with_variables") as format_spec,
+            patch.object(self.engine.loop_orchestrator, "run_conversation_loop", new_callable=AsyncMock) as loop,
+            patch.object(self.engine, "_enrich_variables_with_client_data") as enrich,
+        ):
+            create_client.return_value = Mock()
+            create_user.return_value = Mock()
+            tool_cls.return_value.get_tools_for_agent.return_value = []
+            mas = Mock()
+            mas_cls.return_value.create_swarm_team.return_value = Mock()
+            mas_cls.return_value = mas
+            adapter.autogen_to_contract_format.return_value = {"session_id": "sid", "status": "completed"}
+            format_spec.return_value = Mock(agents={"agent": Mock(tools=[])})
+            enrich.return_value = ({"session_id": "sid"}, None)
+            loop.return_value = ConversationContext("sid", "s", 1, 5, 0.0)
+            result = await self.engine.run_conversation_with_tools(scenario, max_turns=1)
+            assert result["status"] == "completed"
+            enrich.assert_called_once()
+            loop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_error_handling_propagation(self):
+        scenario = {"name": "s", "variables": {}}
+        with (
+            patch("src.autogen_conversation_engine.AutogenModelClientFactory.create_from_openai_wrapper") as create_client,
+            patch.object(self.engine, "_enrich_variables_with_client_data") as enrich,
+            patch.object(self.engine.error_handler, "handle_error_by_type") as handle,
+        ):
+            create_client.side_effect = ValueError("boom")
+            enrich.return_value = ({"session_id": "sid"}, None)
+            handle.return_value = {"status": "failed"}
+            result = await self.engine.run_conversation_with_tools(scenario)
+            handle.assert_called_once()
+            assert result == {"status": "failed"}
+
+    @pytest.mark.asyncio
+    async def test_public_interface_preservation(self):
+        scenario = {"name": "s", "variables": {}}
+        with patch.object(self.engine, "run_conversation_with_tools", new_callable=AsyncMock) as run_tools:
+            run_tools.return_value = {"session_id": "sid", "status": "done", "tools_used": True}
+            result = await self.engine.run_conversation(scenario)
+            run_tools.assert_called_once_with(scenario, None, None)
+            assert result["tools_used"] is False

--- a/llm-simulation-service/tests/test_conversation_loop_orchestrator.py
+++ b/llm-simulation-service/tests/test_conversation_loop_orchestrator.py
@@ -1,0 +1,112 @@
+import asyncio
+import time
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from autogen_agentchat.messages import TextMessage
+from autogen_agentchat.base import TaskResult
+
+from src.conversation_loop_orchestrator import ConversationLoopOrchestrator
+from src.conversation_turn_manager import ConversationTurnManager
+from src.conversation_context import ConversationContext
+from src.logging_utils import SimulationLogger
+from src.turn_result import TurnResult
+
+
+@pytest.fixture
+def context():
+    return ConversationContext(
+        session_id="sid",
+        scenario_name="scenario",
+        max_turns=3,
+        timeout_sec=5,
+        start_time=time.time(),
+    )
+
+@pytest.fixture
+def logger():
+    return Mock(spec=SimulationLogger)
+
+@pytest.fixture
+def turn_manager(logger):
+    mgr = ConversationTurnManager(logger)
+    mgr.execute_turn = AsyncMock()
+    mgr.generate_user_response = AsyncMock(return_value="pong")
+    return mgr
+
+
+class TestConversationLoopOrchestrator:
+    @pytest.mark.asyncio
+    async def test_run_conversation_loop_success(self, context, turn_manager, logger):
+        orchestrator = ConversationLoopOrchestrator(turn_manager, logger)
+        msg = TextMessage(content="hi", source="agent")
+        async def exec_turn(*args, **kwargs):
+            context.turn_count += 1
+            if context.turn_count == 1:
+                return TurnResult(TaskResult(messages=[msg], stop_reason=None), msg, True, None)
+            return TurnResult(TaskResult(messages=[msg], stop_reason="completed"), msg, False, "completed")
+
+        turn_manager.execute_turn.side_effect = exec_turn
+        await orchestrator.run_conversation_loop(Mock(), Mock(), "start", context)
+        assert context.turn_count == 2
+        turn_manager.generate_user_response.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_conversation_loop_timeout(self, context, turn_manager, logger):
+        orchestrator = ConversationLoopOrchestrator(turn_manager, logger)
+        context.timeout_sec = 0
+        with pytest.raises(asyncio.TimeoutError):
+            await orchestrator.run_conversation_loop(Mock(), Mock(), "start", context)
+
+    @pytest.mark.asyncio
+    async def test_run_conversation_loop_max_turns(self, logger):
+        turn_manager = ConversationTurnManager(logger)
+        async def exec_turn(*args, **kwargs):
+            ctx = args[-1]
+            ctx.turn_count += 1
+            return TurnResult(TaskResult(messages=[TextMessage(content="hi", source="agent")], stop_reason=None), TextMessage(content="hi", source="agent"), True, None)
+
+        turn_manager.execute_turn = AsyncMock(side_effect=exec_turn)
+        turn_manager.generate_user_response = AsyncMock(return_value="next")
+        orchestrator = ConversationLoopOrchestrator(turn_manager, logger)
+        ctx = ConversationContext("sid", "scenario", 2, 5, time.time())
+        await orchestrator.run_conversation_loop(Mock(), Mock(), "start", ctx)
+        assert ctx.turn_count == 2
+
+    @pytest.mark.asyncio
+    async def test_run_conversation_loop_natural_termination(self, context, turn_manager, logger):
+        orchestrator = ConversationLoopOrchestrator(turn_manager, logger)
+        msg = TextMessage(content="hi", source="agent")
+        async def exec_turn(*args, **kwargs):
+            context.turn_count += 1
+            return TurnResult(TaskResult(messages=[msg], stop_reason="done"), msg, False, "done")
+
+        turn_manager.execute_turn = AsyncMock(side_effect=exec_turn)
+        await orchestrator.run_conversation_loop(Mock(), Mock(), "start", context)
+        assert context.turn_count == 1
+
+    def test_check_conversation_timeout_within_limit(self, context, turn_manager, logger):
+        orchestrator = ConversationLoopOrchestrator(turn_manager, logger)
+        orchestrator._check_conversation_timeout(context)
+
+    def test_check_conversation_timeout_exceeded(self, context, turn_manager, logger):
+        orchestrator = ConversationLoopOrchestrator(turn_manager, logger)
+        context.timeout_sec = -1
+        with pytest.raises(asyncio.TimeoutError):
+            orchestrator._check_conversation_timeout(context)
+
+    def test_should_continue_conversation_yes(self, context, turn_manager, logger):
+        orchestrator = ConversationLoopOrchestrator(turn_manager, logger)
+        result = TurnResult(TaskResult(messages=[], stop_reason=None), TextMessage(content="hi", source="agent"), True, None)
+        assert orchestrator._should_continue_conversation(context, result)
+
+    def test_should_continue_conversation_no(self, context, turn_manager, logger):
+        orchestrator = ConversationLoopOrchestrator(turn_manager, logger)
+        context.max_turns = 0
+        result = TurnResult(TaskResult(messages=[], stop_reason=None), TextMessage(content="hi", source="agent"), True, None)
+        assert not orchestrator._should_continue_conversation(context, result)
+
+    def test_update_conversation_context(self, context, turn_manager, logger):
+        orchestrator = ConversationLoopOrchestrator(turn_manager, logger)
+        result = TurnResult(TaskResult(messages=[], stop_reason=None), TextMessage(content="hi", source="agent"), True, None)
+        orchestrator._update_conversation_context(context, result)


### PR DESCRIPTION
## Summary
- add ConversationLoopOrchestrator service
- refactor AutogenConversationEngine to delegate loop logic
- add unit tests for ConversationLoopOrchestrator
- add integration tests for engine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f1cdf058832c91af2fa31135f92d